### PR TITLE
Populate library.properties url field

### DIFF
--- a/MAX30102_FUNCIONAL/library.properties
+++ b/MAX30102_FUNCIONAL/library.properties
@@ -5,5 +5,5 @@ maintainer=franklinpc <fpc.yop@gmail.com>
 sentence=Functional Arduino Library modified for use MAX30102 sensor. IPCXX
 paragraph=Modified to work with another arduino boards
 category=Uncategorized
-url=*
+url=https://github.com/PCDCfranklin/MAX30102_FUNCLIB
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.